### PR TITLE
Correct spelling of includes library.properties field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=A finite state machine implementation with a serial reader/debugger
 paragraph=A finite state machine implementation with a serial reader/debugger
 category=Device Control
 architectures=avr
-include=fiKnight.h
+includes=fiKnight.h
 dot_a_linkage=true
 url = https://github.com/cobrce/fiknight


### PR DESCRIPTION
The correct spelling of the field name is includes, not include.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format